### PR TITLE
Use the prop-types package from npm instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 .node_repl_history
 
 .DS_Store
+
+# webStorm config file
+.idea

--- a/chapter-02/controlpanel_with_summary/package.json
+++ b/chapter-02/controlpanel_with_summary/package.json
@@ -47,6 +47,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },

--- a/chapter-02/controlpanel_with_summary/src/Counter.js
+++ b/chapter-02/controlpanel_with_summary/src/Counter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const buttonStyle = {
   margin: '10px'


### PR DESCRIPTION
fix a warning
```
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```

and 

add '.idea' to .gitignore